### PR TITLE
Add Google Sheets district tracker script

### DIFF
--- a/districts_summary.gs
+++ b/districts_summary.gs
@@ -1,0 +1,115 @@
+/**
+ * Google Apps Script to generate a district progress summary.
+ *
+ * Configuration:
+ *  - AREAS_SHEET_NAME: name of the sheet holding area level data.
+ *  - SUMMARY_SHEET_NAME: name for the summary sheet that will be created or updated.
+ *  - TOTALS_SHEET_NAME: optional sheet containing total area counts per district.
+ *    If present and USE_EXTERNAL_TOTALS is true, totals from this sheet will be
+ *    used instead of counting rows in the Areas sheet. The totals sheet is
+ *    expected to have headers in the first row with the district name in column A
+ *    and the total count in column B.
+ */
+
+const AREAS_SHEET_NAME = 'Areas';
+const SUMMARY_SHEET_NAME = 'Districts_Summary';
+const TOTALS_SHEET_NAME = 'District_Totals';
+const USE_EXTERNAL_TOTALS = true; // set to false to always calculate totals
+
+/**
+ * Main entry point to update the summary sheet.
+ * Can be run manually or triggered on edit.
+ */
+function updateDistrictsSummary() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const areasSheet = ss.getSheetByName(AREAS_SHEET_NAME);
+  if (!areasSheet) {
+    SpreadsheetApp.getUi().alert('Areas sheet not found: ' + AREAS_SHEET_NAME);
+    return;
+  }
+  const summarySheet =
+    ss.getSheetByName(SUMMARY_SHEET_NAME) || ss.insertSheet(SUMMARY_SHEET_NAME);
+
+  // Read area data
+  const data = areasSheet.getDataRange().getValues();
+  if (data.length < 2) {
+    return; // nothing to summarise
+  }
+  const header = data[0];
+  const districtIdx = header.indexOf('District');
+  const statusIdx = header.indexOf('Status');
+  if (districtIdx === -1 || statusIdx === -1) {
+    SpreadsheetApp.getUi().alert('Areas sheet must contain District and Status columns.');
+    return;
+  }
+
+  const stats = {};
+  for (let i = 1; i < data.length; i++) {
+    const district = String(data[i][districtIdx]).trim();
+    const status = String(data[i][statusIdx]).trim();
+    if (!district) {
+      continue;
+    }
+    if (!stats[district]) {
+      stats[district] = { total: 0, closed: 0 };
+    }
+    stats[district].total++;
+    if (/^closed$/i.test(status) || /^off[- ]?plan$/i.test(status)) {
+      stats[district].closed++;
+    }
+  }
+
+  // Override totals from an external sheet if configured
+  if (USE_EXTERNAL_TOTALS) {
+    const totalsSheet = ss.getSheetByName(TOTALS_SHEET_NAME);
+    if (totalsSheet) {
+      const totals = totalsSheet.getDataRange().getValues();
+      for (let i = 1; i < totals.length; i++) {
+        const name = String(totals[i][0]).trim();
+        const total = Number(totals[i][1]);
+        if (!name) {
+          continue;
+        }
+        if (!stats[name]) {
+          stats[name] = { total: 0, closed: 0 };
+        }
+        if (!isNaN(total)) {
+          stats[name].total = total;
+        }
+      }
+    }
+  }
+
+  const rows = [['District', 'Total Areas', 'Closed/Off Plan', 'Remaining', 'Completion %', 'Status']];
+  Object.keys(stats)
+    .sort()
+    .forEach(function (district) {
+      const info = stats[district];
+      const remaining = Math.max(0, info.total - info.closed);
+      const completion = info.total ? (info.closed / info.total) * 100 : 0;
+      let status = '⏳ In Progress';
+      if (remaining === 0 && info.total > 0) {
+        status = '✅ Complete';
+      } else if (completion >= 95) {
+        status = '🟡 Almost Complete';
+      } else if (info.closed === 0) {
+        status = '❌ Not Started';
+      }
+      rows.push([district, info.total, info.closed, remaining, completion, status]);
+    });
+
+  summarySheet.clear();
+  summarySheet.getRange(1, 1, rows.length, rows[0].length).setValues(rows);
+  summarySheet.autoResizeColumns(1, rows[0].length);
+}
+
+/**
+ * Simple onEdit trigger that refreshes the summary when changes occur on the Areas sheet.
+ */
+function onEdit(e) {
+  if (!e) return;
+  const editedSheet = e.range.getSheet();
+  if (editedSheet.getName() === AREAS_SHEET_NAME) {
+    updateDistrictsSummary();
+  }
+}

--- a/read.me
+++ b/read.me
@@ -45,3 +45,21 @@ python territory_status_summary.py --file data.json --output-dir reports
 ```
 
 The script writes an Excel file named `territory_status_summary_<timestamp>.xlsx` to the specified output directory.
+
+## Google Sheets District Tracker
+
+The `districts_summary.gs` script is a Google Apps Script that builds an
+up-to-date dashboard summarizing area progress for each district.
+
+### Overview
+- **Areas sheet**: A sheet named `Areas` with columns `District`, `Area_ID` and
+  `Status`.
+- **Summary sheet**: A sheet named `Districts_Summary` is created/updated
+  automatically with totals, completion percentages and an emoji based status.
+- **External totals**: Optionally provide a `District_Totals` sheet listing the
+  total area count per district. Set `USE_EXTERNAL_TOTALS` in the script to use
+  those numbers instead of counting rows.
+
+Whenever you edit the `Areas` sheet, the summary is refreshed automatically via
+an `onEdit` trigger. Run `updateDistrictsSummary()` manually if you need to
+rebuild the table.


### PR DESCRIPTION
## Summary
- add `districts_summary.gs` to generate a district status dashboard inside Google Sheets
- document setup and usage of the new script in `read.me`

## Testing
- `python -m py_compile fetch_slack_messages.py territory_status_summary.py`

------
https://chatgpt.com/codex/tasks/task_e_68630c6071d88326b09021b342777eb8